### PR TITLE
Fixing (nested) limit and while_prec overflow

### DIFF
--- a/examples/abs.real
+++ b/examples/abs.real
@@ -1,7 +1,7 @@
 (* Absolute value *)
 function abs(real x):
   lim n =>
-    let epsilon = 1.0 /. real(shift(1, n)) in
+    let epsilon = 1.0 /. real(shift(1, n+1)) in
     case
     | x <. epsilon => 0.0 -. x
     | epsilon <. x => x

--- a/examples/pi.real
+++ b/examples/pi.real
@@ -1,4 +1,4 @@
-(* *)
+(* compute pi as the unique root of sine(x) contained in (3, 4)  *)
 
 function prec(int x):
   1.0 /. real(shift(1, x))

--- a/examples/pi.real
+++ b/examples/pi.real
@@ -1,0 +1,46 @@
+(* *)
+
+function prec(int x):
+  1.0 /. real(shift(1, x))
+
+function sine (real x):
+  lim p =>
+    var epsilon := prec(p)
+    and n := 0
+    and s := real(1)
+    and r := real(0)
+    and e := x in
+    while
+      (if e >. real(0)
+      then
+        (case real(2) *. e >. epsilon => true | e <. epsilon => false end)
+      else
+        (case real(0)  -. real(2) *. e >. epsilon => true | real(0) -. e <. epsilon => false end))
+    do
+      n := n + 1;
+      r := r +. e *. s;
+      s := s *. real(-1);
+      e := e *. x *. x /. real(2 * n + 1) /. real(2 * n)
+    end; r
+
+function piapprox (int q):
+    var delta := prec(q)
+    and a := real(3)
+    and b := real(4) in
+    while
+      (case
+      | b -. a >. delta /. real(2) => true
+      | b -. a <. delta => false
+      end)
+    do
+      var x := (b +. a) /. real(2) in
+      if
+        sine (x) >. real (0)
+      then
+        a := x
+      else
+        b := x
+    end; a
+
+function pi ():
+  lim q => piapprox (q)

--- a/examples/pi.real
+++ b/examples/pi.real
@@ -17,7 +17,7 @@ function bound(real x, real d):
   end
 
 function nbound(real x, real d):
-  if bound(x, d) then false else true
+  if bound(x, d) then false else true end
 
 function sin (real x):
   lim p =>
@@ -48,6 +48,7 @@ function pi ():
         a := x
       else
         b := x
+      end
       ;
       k := k + 1
     end; a

--- a/examples/pi.real
+++ b/examples/pi.real
@@ -43,7 +43,7 @@ function pi ():
     do
       var x := (a +. b) /. real(2) in
       if
-        sin (x) >. real (0)
+        real (0) <. sin (x)
       then
         a := x
       else
@@ -51,4 +51,4 @@ function pi ():
       end
       ;
       k := k + 1
-    end; a
+    end; (a +. b) /. real(2)

--- a/examples/pi.real
+++ b/examples/pi.real
@@ -3,44 +3,51 @@
 function prec(int x):
   1.0 /. real(shift(1, x))
 
-function sine (real x):
+function abs(real x):
+  lim n =>
+    case
+      x <. prec (n + 1) => real (0) -. x
+    | x >. real (0) -. prec (n + 1) => x
+    end
+
+function bound(real x, real d):
+  case
+    x <. d => true
+  | x >. d /. real(2) => false
+  end
+
+function nbound(real x, real d):
+  if bound(x, d) then false else true
+
+function sin (real x):
   lim p =>
     var epsilon := prec(p)
-    and n := 0
+    and m := 0
     and s := real(1)
-    and r := real(0)
-    and e := x in
-    while
-      (if e >. real(0)
-      then
-        (case real(2) *. e >. epsilon => true | e <. epsilon => false end)
-      else
-        (case real(0)  -. real(2) *. e >. epsilon => true | real(0) -. e <. epsilon => false end))
+    and A := real(0)
+    and q := x in
+    while nbound (q, epsilon)
     do
-      n := n + 1;
-      r := r +. e *. s;
+      m := m + 1;
+      A := A +. q *. s;
       s := s *. real(-1);
-      e := e *. x *. x /. real(2 * n + 1) /. real(2 * n)
-    end; r
+      q := q *. x *. x /. real(2 * m + 1) /. real(2 * m)
+    end; A
 
-function piapprox (int q):
-    var delta := prec(q)
+function pi ():
+  lim n =>
+    var k := 0
     and a := real(3)
     and b := real(4) in
-    while
-      (case
-      | b -. a >. delta /. real(2) => true
-      | b -. a <. delta => false
-      end)
+    while k < n
     do
-      var x := (b +. a) /. real(2) in
+      var x := (a +. b) /. real(2) in
       if
-        sine (x) >. real (0)
+        sin (x) >. real (0)
       then
         a := x
       else
         b := x
+      ;
+      k := k + 1
     end; a
-
-function pi ():
-  lim q => piapprox (q)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -104,7 +104,7 @@ let as_value ~loc v =
     precision level [n], and returns the new stack and the computed value. *)
 let rec comp ~prec stack {Location.data=c; Location.loc} : stack * Value.result =
   if !Config.trace then print_trace ~loc ~prec stack ;
-  let {Runtime.prec_mpfr; Runtime.prec_lim} = prec in
+  let {Runtime.prec_mpfr; Runtime.prec_lim_min} = prec in
   begin match c with
 
   | Syntax.Var k ->

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -91,7 +91,7 @@ plain_term:
   | e=plain_op_term                                             { e }
   | c1=term SEMICOLON c2=term                                   { Sequence (c1, c2) }
   | CASE lst=case_cases END                                     { Case lst }
-  | IF e=op_term THEN c1=term ELSE c2=term                      { If (e, c1, c2) }
+  | IF e=op_term THEN c1=term ELSE c2=term END                  { If (e, c1, c2) }
   | WHILE e=op_term DO c=term END                               { While (e, c) }
   | LET a=separated_nonempty_list(AND,let_clause) IN c=term     { Let (a, c) }
   | VAR a=separated_nonempty_list(AND,var_clause) IN c=term     { Newvar (a, c) }

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -25,6 +25,7 @@ type runtime_error =
   | InvalidExternal of string
   | UnknownExternal of string
   | InternalError of string
+  | FuelOverflow
 
 (** Fuel tells us when to give up on evaluation. *)
 type fuel =
@@ -35,6 +36,9 @@ exception Error of runtime_error Location.located
 
 (** Exception that signals loss of precision *)
 exception NoPrecision
+(** Exception that signals loss of fuel *)
+exception NoFuel
+
 
 (** [error ~loc err] raises the given runtime error. *)
 let error ~loc err = Stdlib.raise (Error (Location.locate ~loc err))
@@ -57,6 +61,7 @@ let rec print_error err ppf =
   | InvalidExternal s -> Format.fprintf ppf "invalid application of %s" s
   | UnknownExternal s ->  Format.fprintf ppf "unknown external function %s" s
   | InternalError s -> Format.fprintf ppf "internal error (%s)" s
+  | FuelOverflow -> Format.fprintf ppf "Max iteration reached"
 
 (** A stack entry *)
 type entry =
@@ -73,17 +78,25 @@ type precision =
     prec_mpfr_min : int;
     prec_lim_min : int;
     prec_mpfr : int;
-    prec_lim : int;
     prec_while : int;
+
+    prec_lim : int list;
+    prec_lim_idx : int;
   }
 
 (** In absence of any knowledge, we scan for each value of [prec_mpfr]
     all values of [prec_lim] up to [prec_mpfr]. *)
 let next_prec ~loc
     ({prec_mpfr_min=k0; prec_lim_min=n0; prec_mpfr=k; prec_lim=n; prec_while=w} as prec) =
-  if 2 * n < k then { prec with prec_lim = n + 1; prec_while = 2*w }
-  else if k >= !Config.max_prec then error ~loc PrecisionLoss
-  else { prec with prec_mpfr = 1 + 3 * k / 2; prec_lim = n0 ; prec_while = 2*w }
+  (* if 2 * n < k then { prec with prec_lim = n + 1} *)
+  (* else  *)
+  if k >= !Config.max_prec then error ~loc PrecisionLoss
+  else { prec with prec_mpfr = 1 + 3 * k / 2}
+
+let next_fuel ~loc
+    ({prec_mpfr_min=k0; prec_lim_min=n0; prec_mpfr=k; prec_lim=n; prec_while=w} as prec) =
+    if 2 * w > w then Some {prec with prec_while = 2*w} else None
+
 
 let initial_prec () =
   let k0 = max 2 !Config.init_prec
@@ -91,12 +104,14 @@ let initial_prec () =
   { prec_mpfr_min = k0 ;
     prec_lim_min = n0 ;
     prec_mpfr = k0 ;
-    prec_lim = n0 ;
     prec_while = 100 ;
+
+    prec_lim = [] ;
+    prec_lim_idx = 0 ;
   }
 
-let print_prec {prec_lim=n; prec_mpfr=k; prec_while=w} ppf =
-  Format.fprintf ppf "(mpfr=%d, lim=%d, while=%d)" k n w
+let print_prec {prec_mpfr=k; prec_while=w} ppf =
+  Format.fprintf ppf "(mpfr=%d, while=%d)" k w
 
 (** The top frame is the one that we can write into, all
     the other frames are read-only. *)

--- a/src/runtime.ml
+++ b/src/runtime.ml
@@ -79,22 +79,20 @@ type precision =
     prec_lim_min : int;
     prec_mpfr : int;
     prec_while : int;
-
-    prec_lim : int list;
-    prec_lim_idx : int;
   }
+
 
 (** In absence of any knowledge, we scan for each value of [prec_mpfr]
     all values of [prec_lim] up to [prec_mpfr]. *)
 let next_prec ~loc
-    ({prec_mpfr_min=k0; prec_lim_min=n0; prec_mpfr=k; prec_lim=n; prec_while=w} as prec) =
+    ({prec_mpfr_min=k0; prec_lim_min=n0; prec_mpfr=k; prec_while=w} as prec) =
   (* if 2 * n < k then { prec with prec_lim = n + 1} *)
   (* else  *)
   if k >= !Config.max_prec then error ~loc PrecisionLoss
   else { prec with prec_mpfr = 1 + 3 * k / 2}
 
 let next_fuel ~loc
-    ({prec_mpfr_min=k0; prec_lim_min=n0; prec_mpfr=k; prec_lim=n; prec_while=w} as prec) =
+    ({prec_mpfr_min=k0; prec_lim_min=n0; prec_mpfr=k;  prec_while=w} as prec) =
     if 2 * w > w then Some {prec with prec_while = 2*w} else None
 
 
@@ -105,10 +103,8 @@ let initial_prec () =
     prec_lim_min = n0 ;
     prec_mpfr = k0 ;
     prec_while = 100 ;
-
-    prec_lim = [] ;
-    prec_lim_idx = 0 ;
   }
+
 
 let print_prec {prec_mpfr=k; prec_while=w} ppf =
   Format.fprintf ppf "(mpfr=%d, while=%d)" k w


### PR DESCRIPTION
These commits fix two errors:

1. nested limits:
Previously, all limit expressions shared the same limit precision `limit_prec`.
This can cause an infinite loop when we evaluate nested limit expressions.
To see a counter example, try running `pi ()` from `examples/pi.real` with the original clerical.
Now, it is fixed so that each limit expressions search for their own limit precisions:
evaluating `lim p => e` first tries with `p = mpfr_prec`. If it fails, it tries `p = 1, 2, 4, 8, ...` until it finds the first limit precision that fails. 

2. while_prec overflow:
Previously, `while_prec : int` could easily suffers int overflow as it gets doubled every time Clerical increases precision.
Now, it is fixed so that `while_prec` gets doubled only when an exception happens due to lack of fuel. And, clerical is set to abort when `while_prec : int` cannot be doubled anymore.